### PR TITLE
chore: enforce pnpm usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 *.log
 *.tmp
 .env*
+package-lock.json
 
 # Vite
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# pnpm을 기본 패키지 매니저로 사용하기 위한 설정입니다.
+package-lock=false
+prefer-workspace-packages=true
+shamefully-hoist=false


### PR DESCRIPTION
## Summary
- add repository-level .npmrc to disable npm lockfiles and prefer pnpm workspace packages
- ignore package-lock.json so stray npm installs cannot reintroduce it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0b7c23de4832d905fe28cde227d91